### PR TITLE
Mail workers are immediately dropped

### DIFF
--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -3,7 +3,7 @@
 class Mastodon::SidekiqMiddleware
   BACKTRACE_LIMIT = 3
 
-  def call(worker, job, queue)
+  def call(_, job, queue)
     # comment this out if mailers workers should not be skipped (i.e. we are sending emails)
     if queue == 'mailers'
       Sidekiq.logger.info("[skip_mailers] dropping #{ job['class'] } (jid=#{job['jid']})")

--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -3,8 +3,13 @@
 class Mastodon::SidekiqMiddleware
   BACKTRACE_LIMIT = 3
 
-  def call(*)
-    yield
+  def call(worker, job, queue)
+    # comment this out if mailers workers should not be skipped (i.e. we are sending emails)
+    if queue == 'mailers'
+      Sidekiq.logger.info("[skip_mailers] dropping #{ job['class'] } (jid=#{job['jid']})")
+    else
+      yield
+    end
   rescue Mastodon::HostValidationError
     # Do not retry
   rescue => e

--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -6,7 +6,7 @@ class Mastodon::SidekiqMiddleware
   def call(_, job, queue)
     # comment this out if mailers workers should not be skipped (i.e. we are sending emails)
     if queue == 'mailers'
-      Sidekiq.logger.info("[skip_mailers] dropping #{ job['class'] } (jid=#{job['jid']})")
+      Sidekiq.logger.info("[skip_mailers] dropping #{job['class']} (jid=#{job['jid']})")
     else
       yield
     end


### PR DESCRIPTION
Adds sidekiq middleware that automatically drops all workers added to the `mailers` queue. Logs this behavior.