### PR TITLE
Expose regeneration to an external facing API

### DIFF
--- a/app/controllers/api/v1/timelines/regenerate_controller.rb
+++ b/app/controllers/api/v1/timelines/regenerate_controller.rb
@@ -1,0 +1,31 @@
+class Api::V1::Timelines::RegenerateController < Api::BaseController
+    def create
+        regenerate
+    end
+
+    def regenerate
+        # Accept account_id as a param, fallback to current_user if not provided
+        account_id = params[:account_id]
+
+        if account_id.nil?
+        render json: { error: "Account ID is required" }, status: :bad_request and return
+        end 
+
+        account = Account.find_by(id: account_id)
+        if account.nil?
+            render json: { error: "Account not found" }, status: :not_found and return
+        end
+
+        user = account.user
+        if user.nil?
+            render json: { error: "No local user for this account" }, status: :unprocessable_entity and return
+        end
+
+        # unless current_user.admin? || current_user.account.id == account.id
+        #   render json: { error: "Forbidden" }, status: :forbidden and return
+        # end
+
+        user.regenerate_feed!
+        render json: { message: "Feed regeneration started for user #{account.id}" }, status: :accepted
+    end
+end

--- a/app/models/user_post_score.rb
+++ b/app/models/user_post_score.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_post_scores
+#
+#  id         :bigint(8)        not null, primary key
+#  user_id    :bigint(8)        not null
+#  status_id  :bigint(8)        not null
+#  score      :float            not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_user_post_scores_on_user_id_and_status_id  (user_id,status_id) UNIQUE
+#  index_user_post_scores_on_status_id              (status_id)
+#
+class UserPostScore < ApplicationRecord
+  belongs_to :user, class_name: 'Account'
+  belongs_to :status
+
+  validates :user_id, presence: true
+  validates :status_id, presence: true
+  validates :score, presence: true
+  validates :user_id, uniqueness: { scope: :status_id }
+
+  # Convert a hash of scores from the scoring service to UserPostScore objects
+  # @param scores [Hash<Integer, Hash<Integer, Float>>] Hash mapping status_id -> user_id -> score
+  # @return [Array<UserPostScore>] Array of UserPostScore objects
+  def self.from_score_hash(scores)
+    scores.flat_map do |status_id, user_scores|
+      user_scores.map do |user_id, score|
+        new(
+          status_id: status_id,
+          user_id: user_id,
+          score: score
+        )
+      end
+    end
+  end
+
+  # Convert an array of UserPostScore objects to the hash format expected by the feed manager
+  # @param scores [Array<UserPostScore>] Array of UserPostScore objects
+  # @return [Hash<Integer, Hash<Integer, Float>>] Hash mapping status_id -> user_id -> score
+  def self.to_score_hash(scores)
+    scores.each_with_object({}) do |score, hash|
+      hash[score.status_id] ||= {}
+      hash[score.status_id][score.user_id] = score.score
+    end
+  end
+end 

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -113,7 +113,7 @@ class FanOutOnWriteService < BaseService
         Rails.logger.info "Received batch scores: #{scores.inspect}"
         FeedInsertWorker.push_bulk(followers) do |follower|
           [ @status.id, follower.id, 'home',
-            { update: update?, score: scores.dig(@status.id.to_s, follower.id.to_s) } ]
+            { update: update?, score: scores.dig(@status.id, follower.id) } ]
         end
       end
     end

--- a/app/services/locutus/fetch_scores_service.rb
+++ b/app/services/locutus/fetch_scores_service.rb
@@ -1,19 +1,30 @@
+# frozen_string_literal: true
+
 # app/services/locutus/fetch_scores_service.rb
-class Locutus::FetchScoresService < BaseService
-  SCORE_API_URI = URI('http://67.207.93.201:5001/analysis/batched-get-score')
+module Locutus
+  class FetchScoresService < BaseService
+    SCORE_API_URI = URI('http://67.207.93.201:5001/analysis/batched-get-score')
 
-  def self.call(status_ids:, user_ids:)
-    new.call(status_ids: status_ids, user_ids: user_ids)
-  end
+    def self.call(status_ids:, user_ids:)
+      new.call(status_ids: status_ids, user_ids: user_ids)
+    end
 
-  def call(status_ids:, user_ids:)
-    http    = Net::HTTP.new(SCORE_API_URI.host, SCORE_API_URI.port)
-    request = Net::HTTP::Get.new(SCORE_API_URI.path, 'Content-Type' => 'application/json')
-    request.body = { status_ids: status_ids.map(&:to_s), user_ids: user_ids.map(&:to_s) }.to_json
+    # @param status_ids [Array<Integer>] List of status IDs to fetch scores for
+    # @param user_ids [Array<Integer>] List of user IDs to fetch scores for
+    # @return [Hash<Integer, Hash<Integer, Float>>] A hash mapping status_id -> user_id -> score
+    def call(status_ids:, user_ids:)
+      http    = Net::HTTP.new(SCORE_API_URI.host, SCORE_API_URI.port)
+      request = Net::HTTP::Get.new(SCORE_API_URI.path, 'Content-Type' => 'application/json')
+      request.body = { status_ids: status_ids.map(&:to_s), user_ids: user_ids.map(&:to_s) }.to_json
 
-    response = http.request(request)
-    raise "Score API error: #{response.code} #{response.body}" unless response.code == '200'
+      response = http.request(request)
+      raise "Score API error: #{response.code} #{response.body}" unless response.code == '200'
 
-    JSON.parse(response.body)['scores']
+      # Parse the response into a Hash<status_id, Hash<user_id, score>>
+      scores = JSON.parse(response.body)['scores']
+      scores.transform_keys!(&:to_i)
+      scores.each_value { |user_scores| user_scores.transform_keys!(&:to_i) }
+      scores
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -473,6 +473,7 @@ Rails.application.routes.draw do
         resource :public, only: :show, controller: :public
         resources :tag, only: :show
         resources :list, only: :show
+        resource :regenerate, only: :create, controller: :regenerate
       end
 
       resources :streaming, only: [:index]


### PR DESCRIPTION
- **New Regenerate Endpoint**  
  `Api::V1::Timelines::RegenerateController#create` accepts an `account_id` (or falls back to `current_user`), validates the account, enqueues `user.regenerate_feed!`, and returns `202 Accepted` (or `400/404/422` on error).

- **Routes**  
  Adds `POST /api/v1/timelines/regenerate` under the `api/v1/timelines` namespace.

- **User Model Helpers**  
  Makes `regenerate_feed!` and `regenerate_feed_override!` public methods to enqueue `RegenerationWorker` and `RegenerationWorkerPrio`, respectively.

- **FetchScoresService Cleanup**  
  Namespaced under `Locutus`, uses integer keys (not strings), and parses the JSON response into a `Hash<Integer, Hash<Integer, Float>>`.  