### PR TITLE
Make an endpoint for adding to an account's home feed

### DIFF
--- a/app/controllers/api/v1/timelines/add_to_feed_controller.rb
+++ b/app/controllers/api/v1/timelines/add_to_feed_controller.rb
@@ -1,0 +1,40 @@
+class Api::V1::Timelines::AddToFeedController < Api::BaseController
+    def create
+        add_to_feed
+    end
+
+    def add_to_feed
+        account_id = params[:account_id]
+        status_id = params[:status_id]
+        score = params[:score]
+
+        if account_id.nil?
+            render json: { error: "Account ID is required" }, status: :bad_request and return
+        end 
+
+        if status_id.nil?
+            render json: { error: "Status ID is required" }, status: :bad_request and return
+        end
+
+        account = Account.find_by(id: account_id)
+        if account.nil?
+            render json: { error: "Account not found" }, status: :not_found and return
+        end
+
+        status = Status.find_by(id: status_id)
+        if status.nil?
+            render json: { error: "Status not found" }, status: :not_found and return
+        end
+
+        # unless current_user.admin? || current_user.account.id == account.id
+        #   render json: { error: "Forbidden" }, status: :forbidden and return
+        # end
+
+        result = FeedManager.instance.push_to_home(account, status, score: score)
+        if result
+            render json: { message: "Status added to feed for account #{account.id}" }, status: :accepted
+        else
+            render json: { error: "Failed to add status to feed" }, status: :internal_server_error
+        end
+    end
+end

--- a/app/controllers/api/v1/timelines/regenerate_controller.rb
+++ b/app/controllers/api/v1/timelines/regenerate_controller.rb
@@ -26,6 +26,6 @@ class Api::V1::Timelines::RegenerateController < Api::BaseController
         # end
 
         user.regenerate_feed!
-        render json: { message: "Feed regeneration started for user #{account.id}" }, status: :accepted
+        render json: { message: "Feed regeneration started for account #{account.id}" }, status: :accepted
     end
 end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -69,10 +69,10 @@ class FeedManager
     status_id = status.id
     user_id = account.id
 
-    Rails.logger.info "feed_manager test log: push_to_home canary"
-    Rails.logger.info "push_to_home canary account.id: #{user_id}, status.id: #{status_id}"
+    # Rails.logger.info "feed_manager test log: push_to_home canary"
+    # Rails.logger.info "push_to_home canary account.id: #{user_id}, status.id: #{status_id}"
 
-    Rails.logger.info "push_to_home canary Current status text is #{status.text}"
+    # Rails.logger.info "push_to_home canary Current status text is #{status.text}"
 
     # Define the URL and request data
     if score.nil?

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -1,4 +1,3 @@
-# to do: modify this to fix pagination
 # frozen_string_literal: true
 
 class HomeFeed < Feed
@@ -17,60 +16,25 @@ class HomeFeed < Feed
     since_id = since_id.to_i if since_id.present?
     min_id   = min_id.to_i if min_id.present?
 
-    Rails.logger.info "home_feed.rb get: key=#{key}, limit=#{limit}, max_id=#{max_id}, since_id=#{since_id}, min_id=#{min_id}"
-
     from_redis(limit, max_id, since_id, min_id)
   end
 
-  # def from_redis_withscores(limit, max_id, since_id, min_id)
-  #   if min_id == '-inf'
-  #     unhydrated_with_scores = redis.zrevrangebyscore(key, "(#{max_id}", "(#{since_id}", limit: [0, limit], with_scores: true)
-  #   else
-  #     unhydrated_with_scores = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true)
-  #   end
-  
-  #   # Create a map of ID to score
-  #   score_map = unhydrated_with_scores.to_h
-  
-  #   # Fetch statuses and include scores
-  #   Status.where(id: score_map.keys.map(&:to_i)).cache_ids.map do |status|
-  #     status.define_singleton_method(:score) { score_map[status.id.to_s] }
-  #     status
-  #   end.sort_by { |status| -status.score }
-  # end
-  
-
   def from_redis(limit, max_id, since_id, min_id)
-    Rails.logger.info "home_feed.rb from_redis START: key=#{key}, limit=#{limit}, max_id=#{max_id}, since_id=#{since_id}, min_id=#{min_id}"
-  
     # Resolve max_id, since_id, and min_id to their corresponding scores
     max_score = max_id.present? ? redis.zscore(key, max_id) || '+inf' : '+inf'
-    Rails.logger.info "home_feed.rb Resolved max_score=#{max_score} for max_id=#{max_id}"
-  
     since_score = since_id.present? ? redis.zscore(key, since_id) || '-inf' : '-inf'
-    Rails.logger.info "home_feed.rb Resolved since_score=#{since_score} for since_id=#{since_id}"
-  
     min_score = min_id.present? ? redis.zscore(key, min_id) || '-inf' : nil
-    Rails.logger.info "home_feed.rb Resolved min_score=#{min_score} for min_id=#{min_id}"
-  
+
     # Fetch unhydrated keys and their scores based on resolved scores
     if min_score.nil?
-      Rails.logger.info "home_feed.rb Fetching scores using zrevrangebyscore with max_score=#{max_score} and since_score=#{since_score}, limit=#{limit}"
       hydrated_with_scores = redis.zrevrangebyscore(key, "(#{max_score}", "(#{since_score}", limit: [0, limit], with_scores: true)
     else
-      Rails.logger.info "home_feed.rb Fetching scores using zrangebyscore with min_score=#{min_score} and max_score=#{max_score}, limit=#{limit}"
       hydrated_with_scores = redis.zrangebyscore(key, "(#{min_score}", "(#{max_score}", limit: [0, limit], with_scores: true)
     end
-  
-    Rails.logger.info "home_feed.rb Fetched hydrated_with_scores: #{hydrated_with_scores.inspect}"
-  
+
     # Map unhydrated keys and their scores
     u_map = hydrated_with_scores.to_h { |key, score| [key.to_i, score.to_f] }
-    Rails.logger.info "home_feed.rb Mapped u_map: #{u_map.inspect}"
-  
-    # Additional processing or return statement here
-    Rails.logger.info "home_feed.rb home_feed.rb from_redis END"
-  
+
     # Map unhydrated keys and sort them by scores in descending order
     Status.where(id: u_map.keys).cache_ids.sort_by { |status| -u_map[status.id.to_s].to_f }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -474,6 +474,7 @@ Rails.application.routes.draw do
         resources :tag, only: :show
         resources :list, only: :show
         resource :regenerate, only: :create, controller: :regenerate
+        resource :add_to_feed, only: :create, controller: :add_to_feed
       end
 
       resources :streaming, only: [:index]


### PR DESCRIPTION
- Expose “add to feed” endpoint: introduces POST /api/v1/timelines/add_to_feed to let external services push an existing status into a user’s home feed (accepts `account_id`, `status_id` and optional `score`).
- `AddToFeedController` validates presence and existence of both account_id and status_id, returning error as appropiate