### PR TITLE
Expand feed management rate limits

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -62,6 +62,11 @@ class Rack::Attack
     req.remote_ip == '127.0.0.1' || req.remote_ip == '::1'
   end
 
+  Rack::Attack.safelist('feed-management') do |req|
+    req.path.start_with?('/api/v1/timelines/add_to_feed') ||
+      req.path.start_with?('/api/v1/timelines/remove_from_feed')
+  end
+
   Rack::Attack.blocklist('deny from blocklist') do |req|
     IpBlock.blocked?(req.remote_ip)
   end
@@ -70,7 +75,7 @@ class Rack::Attack
     req.authenticated_user_id if req.api_request?
   end
 
-  throttle('throttle_per_token_api', limit: 300, period: 5.minutes) do |req|
+  throttle('throttle_per_token_api', limit: 99999, period: 5.minutes) do |req|
     req.authenticated_token_id if req.api_request?
   end
 


### PR DESCRIPTION
## Summary
- safelist custom `/add_to_feed` and `/remove_from_feed` endpoints
- raise `throttle_per_token_api` limit to 99999

## Testing
- `bundle check` *(fails: rbenv version `3.0.4` is not installed)*
- `mise install ruby` *(fails: 403 when downloading openssl)*

------
https://chatgpt.com/codex/tasks/task_e_6876f1b6a9a8832a8ca602a6ec5f649d