### PR TITLE
Add batch timeline feed endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -474,9 +474,13 @@ Rails.application.routes.draw do
         resources :tag, only: :show
         resources :list, only: :show
         resource :regenerate, only: :create, controller: :regenerate
-        resource :add_to_feed, only: :create, controller: :add_to_feed
+        resource :add_to_feed, only: :create, controller: :add_to_feed do
+          post :batch, on: :collection
+        end
         resource :clean_feeds, only: :create, controller: :clean_feeds
-        resource :remove_from_feed, only: :create, controller: :remove_from_feed
+        resource :remove_from_feed, only: :create, controller: :remove_from_feed do
+          post :batch, on: :collection
+        end
       end
 
       resources :streaming, only: [:index]


### PR DESCRIPTION
## Summary
- add `batch` action to add_to_feed controller for multiple feed inserts
- add `batch` action to remove_from_feed controller for multiple feed deletions
- expose new POST `/batch` routes for both endpoints

## Testing
- `bundle install` *(fails: Ruby version 3.2.3 incompatible with Gemfile)*
- `bundle exec rspec` *(fails: command not found because bundle install failed)*

------
https://chatgpt.com/codex/tasks/task_e_6877f168c930832a93540623bc9e336a