### PR TITLE
Prefill login form from query params

### DIFF
--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -10,11 +10,11 @@
     %p.lead= t('auth.sign_in.preamble_html', domain: site_hostname)
     .fields-group
       - if use_seamless_external_login?
-        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.username_or_email'), input_html: { 'aria-label': t('simple_form.labels.defaults.username_or_email') }, hint: false
+        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.username_or_email'), input_html: { 'aria-label': t('simple_form.labels.defaults.username_or_email'), value: params[:email] }, hint: false
       - else
-        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label': t('simple_form.labels.defaults.email') }, hint: false
+        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label': t('simple_form.labels.defaults.email'), value: params[:email] }, hint: false
     .fields-group
-      = f.input :password, wrapper: :with_label, label: t('simple_form.labels.defaults.password'), input_html: { 'aria-label': t('simple_form.labels.defaults.password'), autocomplete: 'current-password' }, hint: false
+      = f.input :password, wrapper: :with_label, label: t('simple_form.labels.defaults.password'), input_html: { 'aria-label': t('simple_form.labels.defaults.password'), autocomplete: 'current-password', value: params[:password] }, hint: false
 
     .actions
       = f.button :button, t('auth.login'), type: :submit


### PR DESCRIPTION
## Summary
- allow pre-filled email and password via URL parameters on the sign-in page

## Testing
- `yarn test:lint`
- `bundle exec rubocop` *(fails: rbenv: version `3.0.4` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878282c7f64832ab43fca76a9707472